### PR TITLE
Add PostgreSQL persistence and CRUD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ cd SensorFlow
 docker-compose up -d
 ```
 
+Set the `DATABASE_URL` environment variable to point to your PostgreSQL instance. Example:
+
+```bash
+export DATABASE_URL=postgresql://sensorflow:password@localhost:5432/sensorflow
+```
+
+On startup the API will automatically create a `sensor_readings` table if it does not exist.
+
 **Access the interfaces:**
 - API docs: http://localhost:8000/docs
 - Grafana dashboards: http://localhost:3000 (admin/admin)
@@ -44,8 +52,11 @@ This generates sample data and shows you how the system works.
 - `GET /` - Basic API information
 - `GET /health` - Service health status
 - `GET /sensors` - List active sensors
-- `GET /readings` - Retrieve sensor data
+- `GET /readings` - List sensor data
 - `POST /readings` - Submit new readings
+- `GET /readings/{id}` - Retrieve a single reading
+- `PUT /readings/{id}` - Update a reading
+- `DELETE /readings/{id}` - Delete a reading
 - `POST /simulate` - Generate test data
 - `GET /stats` - System statistics
 
@@ -82,6 +93,7 @@ Data flows from simulated sensors through the API into InfluxDB for storage. Gra
 ```bash
 pip install -r requirements.txt
 cd src
+export DATABASE_URL=postgresql://sensorflow:password@localhost:5432/sensorflow
 uvicorn api.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
@@ -124,6 +136,23 @@ curl http://localhost:8000/sensors
 **Generate sample data:**
 ```bash
 curl -X POST http://localhost:8000/simulate?count=100
+```
+
+**Read a specific entry:**
+```bash
+curl http://localhost:8000/readings/1
+```
+
+**Update an entry:**
+```bash
+curl -X PUT -H "Content-Type: application/json" \
+     -d '{"sensor_id":"temp_sensor_01","sensor_type":"temperature","value":22.5,"unit":"°C","timestamp":"2024-01-01T00:00:00","location":"Floor 1"}' \
+     http://localhost:8000/readings/1
+```
+
+**Delete an entry:**
+```bash
+curl -X DELETE http://localhost:8000/readings/1
 ```
 
 **View statistics:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ faker==20.1.0
 
 # Async Support
 aiohttp==3.9.1
+asyncpg==0.29.0

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -11,6 +11,8 @@ from datetime import datetime
 import json
 import asyncio
 import random
+import os
+import asyncpg
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -45,8 +47,31 @@ class HealthResponse(BaseModel):
     timestamp: datetime
     services: dict
 
-# In-memory storage for demo (in production, use a real database)
-sensor_readings: List[SensorReading] = []
+# Database connection settings
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/sensorflow")
+
+@app.on_event("startup")
+async def startup_event():
+    """Create database connection pool and ensure table exists."""
+    app.state.pool = await asyncpg.create_pool(dsn=DATABASE_URL)
+    create_table = """
+        CREATE TABLE IF NOT EXISTS sensor_readings (
+            id SERIAL PRIMARY KEY,
+            sensor_id TEXT NOT NULL,
+            sensor_type TEXT NOT NULL,
+            value DOUBLE PRECISION NOT NULL,
+            unit TEXT NOT NULL,
+            timestamp TIMESTAMPTZ NOT NULL,
+            location TEXT
+        );
+    """
+    async with app.state.pool.acquire() as conn:
+        await conn.execute(create_table)
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Close database connection pool."""
+    await app.state.pool.close()
 
 @app.get("/", response_model=dict)
 async def root():
@@ -89,22 +114,94 @@ async def get_sensors():
 @app.get("/readings", response_model=List[SensorReading])
 async def get_readings(limit: int = 100):
     """Get recent sensor readings."""
-    return sensor_readings[-limit:]
+    query = """SELECT sensor_id, sensor_type, value, unit, timestamp, location
+               FROM sensor_readings
+               ORDER BY id DESC
+               LIMIT $1"""
+    async with app.state.pool.acquire() as conn:
+        rows = await conn.fetch(query, limit)
+    return [SensorReading(**dict(r)) for r in rows]
+
 
 @app.post("/readings", response_model=dict)
 async def add_reading(reading: SensorReading):
     """Add a new sensor reading."""
-    sensor_readings.append(reading)
-    logger.info(f"Added reading from {reading.sensor_id}: {reading.value} {reading.unit}")
+    query = """INSERT INTO sensor_readings
+               (sensor_id, sensor_type, value, unit, timestamp, location)
+               VALUES ($1, $2, $3, $4, $5, $6)"""
+    async with app.state.pool.acquire() as conn:
+        await conn.execute(
+            query,
+            reading.sensor_id,
+            reading.sensor_type,
+            reading.value,
+            reading.unit,
+            reading.timestamp,
+            reading.location,
+        )
+    logger.info(
+        f"Added reading from {reading.sensor_id}: {reading.value} {reading.unit}"
+    )
     return {"status": "success", "message": "Reading added"}
+
+
+@app.get("/readings/{reading_id}", response_model=SensorReading)
+async def get_reading(reading_id: int):
+    """Retrieve a single sensor reading by ID."""
+    query = """SELECT sensor_id, sensor_type, value, unit, timestamp, location
+               FROM sensor_readings WHERE id=$1"""
+    async with app.state.pool.acquire() as conn:
+        row = await conn.fetchrow(query, reading_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Reading not found")
+    return SensorReading(**dict(row))
+
+
+@app.put("/readings/{reading_id}", response_model=SensorReading)
+async def update_reading(reading_id: int, reading: SensorReading):
+    """Update an existing sensor reading."""
+    query = """UPDATE sensor_readings SET
+                sensor_id=$1,
+                sensor_type=$2,
+                value=$3,
+                unit=$4,
+                timestamp=$5,
+                location=$6
+                WHERE id=$7
+                RETURNING sensor_id, sensor_type, value, unit, timestamp, location"""
+    async with app.state.pool.acquire() as conn:
+        row = await conn.fetchrow(
+            query,
+            reading.sensor_id,
+            reading.sensor_type,
+            reading.value,
+            reading.unit,
+            reading.timestamp,
+            reading.location,
+            reading_id,
+        )
+    if not row:
+        raise HTTPException(status_code=404, detail="Reading not found")
+    return SensorReading(**dict(row))
+
+
+@app.delete("/readings/{reading_id}", response_model=dict)
+async def delete_reading(reading_id: int):
+    """Delete a sensor reading by ID."""
+    query = "DELETE FROM sensor_readings WHERE id=$1"
+    async with app.state.pool.acquire() as conn:
+        result = await conn.execute(query, reading_id)
+    if result.endswith("0"):
+        raise HTTPException(status_code=404, detail="Reading not found")
+    return {"status": "success", "message": "Reading deleted"}
 
 @app.post("/simulate", response_model=dict)
 async def simulate_data(count: int = 10):
     """Simulate sensor data for demo purposes."""
     sensor_types = ["temperature", "pressure", "vibration", "humidity"]
     units = {"temperature": "°C", "pressure": "bar", "vibration": "m/s²", "humidity": "%"}
-    
-    for i in range(count):
+
+    for _ in range(count):
         sensor_type = random.choice(sensor_types)
         reading = SensorReading(
             sensor_id=f"{sensor_type}_sensor_0{random.randint(1,3)}",
@@ -112,26 +209,35 @@ async def simulate_data(count: int = 10):
             value=round(random.uniform(10, 100), 2),
             unit=units[sensor_type],
             timestamp=datetime.now(),
-            location=f"Factory Floor {random.randint(1,5)}"
+            location=f"Factory Floor {random.randint(1,5)}",
         )
-        sensor_readings.append(reading)
-    
+        await add_reading(reading)
+
     return {"status": "success", "message": f"Generated {count} sensor readings"}
 
 @app.get("/stats", response_model=dict)
 async def get_statistics():
     """Get basic statistics about sensor data."""
-    if not sensor_readings:
-        return {"total_readings": 0, "sensors": [], "latest_reading": None}
-    
-    sensor_ids = list(set([r.sensor_id for r in sensor_readings]))
-    latest_reading = sensor_readings[-1] if sensor_readings else None
-    
+    async with app.state.pool.acquire() as conn:
+        total_readings = await conn.fetchval(
+            "SELECT COUNT(*) FROM sensor_readings"
+        )
+        sensor_rows = await conn.fetch(
+            "SELECT DISTINCT sensor_id FROM sensor_readings"
+        )
+        latest = await conn.fetchrow(
+            "SELECT sensor_id, sensor_type, value, unit, timestamp, location\n"
+            "FROM sensor_readings ORDER BY timestamp DESC LIMIT 1"
+        )
+
+    sensors = [r["sensor_id"] for r in sensor_rows]
+    latest_reading = SensorReading(**dict(latest)).dict() if latest else None
+
     return {
-        "total_readings": len(sensor_readings),
-        "unique_sensors": len(sensor_ids),
-        "sensors": sensor_ids,
-        "latest_reading": latest_reading.dict() if latest_reading else None
+        "total_readings": total_readings,
+        "unique_sensors": len(sensors),
+        "sensors": sensors,
+        "latest_reading": latest_reading,
     }
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `asyncpg` to requirements
- connect to PostgreSQL via `DATABASE_URL`
- persist sensor readings in `sensor_readings` table
- implement CRUD endpoints backed by the database
- document database setup and new endpoints in README

## Testing
- `python3 -m py_compile src/api/main.py src/data_generator.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68541d6c99f0832189f8711c4c97b433